### PR TITLE
Changing code to use the new 0.2.0 opencolor lib

### DIFF
--- a/lib/aco.js
+++ b/lib/aco.js
@@ -9,8 +9,6 @@ var _factory = require('./factory');
 
 var _opencolor = require('opencolor');
 
-var _opencolor2 = _interopRequireDefault(_opencolor);
-
 var _color = require('color');
 
 var _color2 = _interopRequireDefault(_color);
@@ -26,7 +24,7 @@ var defaultImporterOptions = {};
 var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOptions, function (input, options) {
   return new Promise(function (resolve, reject) {
     var buf = input;
-    var ocoPalette = new _opencolor2.default.Entry();
+    var ocoPalette = new _opencolor.Entry();
 
     // https:// github.com/teemualap/grunt-aco2less
     var nTotalColors = 0;
@@ -128,7 +126,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
       if (color.colorSpace === 0) {
         // RGB
         var colorValue = (0, _color2.default)().rgb(color.w / 256, color.x / 256, color.y / 256);
-        var colorEntry = new _opencolor2.default.Entry(colorName, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+        var colorEntry = new _opencolor.Entry(colorName, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
 
         path.push(colorName);
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -11,8 +11,6 @@ var _factory = require('./factory');
 
 var _opencolor = require('opencolor');
 
-var _opencolor2 = _interopRequireDefault(_opencolor);
-
 var _color = require('color');
 
 var _color2 = _interopRequireDefault(_color);
@@ -62,7 +60,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
           Promise.reject(e);
         }
 
-        var ocoPalette = new _opencolor2.default.Entry();
+        var ocoPalette = new _opencolor.Entry();
 
         function walk(key, value, path, parent, level) {
           path = path.slice(0);
@@ -86,7 +84,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
               if (options.readNameFromKey && (typeof parent === 'undefined' ? 'undefined' : _typeof(parent)) === 'object' && options.keyForName in parent) {
                 name = parent[options.keyForName];
               }
-              var color = new _opencolor2.default.Entry(name, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+              var color = new _opencolor.Entry(name, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
               path.push(name);
               ocoPalette.set(path.join('.'), color);
             }
@@ -124,7 +122,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
           Promise.reject(e);
         }
 
-        var ocoPalette = new _opencolor2.default.Entry();
+        var ocoPalette = new _opencolor.Entry();
 
         function walk(key, value, path, parent, level) {
           path = path.slice(0);
@@ -148,7 +146,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
               if (options.readNameFromKey && (typeof parent === 'undefined' ? 'undefined' : _typeof(parent)) === 'object' && options.keyForName in parent) {
                 name = parent[options.keyForName];
               }
-              var color = new _opencolor2.default.Entry(name, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+              var color = new _opencolor.Entry(name, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
               path.push(name);
               ocoPalette.set(path.join('.'), color);
             }

--- a/lib/json.js
+++ b/lib/json.js
@@ -11,8 +11,6 @@ var _factory = require('./factory');
 
 var _opencolor = require('opencolor');
 
-var _opencolor2 = _interopRequireDefault(_opencolor);
-
 var _color = require('color');
 
 var _color2 = _interopRequireDefault(_color);
@@ -34,7 +32,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
     Promise.reject(e);
   }
   return new Promise(function (resolve, reject) {
-    var ocoPalette = new _opencolor2.default.Entry();
+    var ocoPalette = new _opencolor.Entry();
 
     function walk(key, value, path, parent, level) {
       path = path.slice(0);
@@ -58,7 +56,7 @@ var importer = exports.importer = (0, _factory.createImporter)(defaultImporterOp
           if (options.readNameFromKey && (typeof parent === 'undefined' ? 'undefined' : _typeof(parent)) === 'object' && options.keyForName in parent) {
             name = parent[options.keyForName];
           }
-          var color = new _opencolor2.default.Entry(name, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+          var color = new _opencolor.Entry(name, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
           path.push(name);
           ocoPalette.set(path.join('.'), color);
         }

--- a/lib/stylesheet.js
+++ b/lib/stylesheet.js
@@ -15,13 +15,11 @@ var _color2 = _interopRequireDefault(_color);
 
 var _opencolor = require('opencolor');
 
-var _opencolor2 = _interopRequireDefault(_opencolor);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var stylsheetImporter = exports.stylsheetImporter = function stylsheetImporter(input, options, syntax) {
   return new Promise(function (resolve, reject) {
-    var ocoPalette = new _opencolor2.default.Entry();
+    var ocoPalette = new _opencolor.Entry();
 
     var parseTree = _gonzalesPe2.default.parse(input, { syntax: syntax });
 
@@ -48,7 +46,7 @@ var stylsheetImporter = exports.stylsheetImporter = function stylsheetImporter(i
       if (node.contains('color')) {
         var variableName = node.first('atkeyword').first('ident').content;
         var colorValue = (0, _color2.default)('#' + node.first('color').content);
-        var colorEntry = new _opencolor2.default.Entry(variableName, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+        var colorEntry = new _opencolor.Entry(variableName, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
         ocoPalette.set(variableName, colorEntry);
       }
     });
@@ -60,11 +58,11 @@ var stylsheetImporter = exports.stylsheetImporter = function stylsheetImporter(i
 
         if (node.contains('value') && node.first('value').contains('color')) {
           var colorValue = (0, _color2.default)('#' + node.first('value').first('color').content);
-          var colorEntry = new _opencolor2.default.Entry(variableName, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+          var colorEntry = new _opencolor.Entry(variableName, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
           ocoPalette.set(variableName, colorEntry);
         } else if (node.contains('value') && node.first('value').contains('variable')) {
           var path = node.first('value').first('variable').first('ident').content;
-          var refrenceEntry = new _opencolor2.default.Reference(variableName, path);
+          var refrenceEntry = new _opencolor.Reference(variableName, path);
           ocoPalette.set(variableName, refrenceEntry);
         }
       }
@@ -75,7 +73,7 @@ var stylsheetImporter = exports.stylsheetImporter = function stylsheetImporter(i
       if (node.contains('value') && node.first('value').contains('variable')) {
         var variableName = node.first('property').first('ident').content
         var path = node.first('value').first('variable').first('ident').content
-        var refrenceEntry = new oco.Reference(variableName, path)
+        var refrenceEntry = new Reference(variableName, path)
         ocoPalette.set(variableName, refrenceEntry)
       }
     })
@@ -103,11 +101,11 @@ var stylsheetImporter = exports.stylsheetImporter = function stylsheetImporter(i
         node.traverseByTypes(['value'], function (node, index, parent) {
           node.traverseByTypes(['color'], function (node, index, parent) {
             var colorValue = (0, _color2.default)('#' + node.content);
-            var colorEntry = new _opencolor2.default.Entry(cssProperty, [_opencolor2.default.ColorValue.fromColorValue(colorValue.hexString())]);
+            var colorEntry = new _opencolor.Entry(cssProperty, [_opencolor.ColorValue.fromColorValue(colorValue.hexString())]);
             addEntryWithSelectors(selectors, cssProperty, colorEntry);
           });
           node.traverseByTypes(['variable'], function (node, index, parent) {
-            var refrenceEntry = new _opencolor2.default.Reference(cssProperty, node.first('ident').content);
+            var refrenceEntry = new _opencolor.Reference(cssProperty, node.first('ident').content);
             addEntryWithSelectors(selectors, cssProperty, refrenceEntry);
           });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencolor-converter",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "Converts files with colors towards Open Color File Format",
   "main": "lib/index.js",
   "scripts": {
@@ -16,6 +16,7 @@
     "url": "https://github.com/opencolor-tools/opencolor-converter/issues"
   },
   "homepage": "https://github.com/opencolor-tools/opencolor-converter",
+  "repository": "https://github.com/opencolor-tools/opencolor-converter",
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-core": "^6.8.0",
@@ -36,6 +37,6 @@
     "get-image-colors": "github:ChristophLabacher/get-image-colors",
     "gonzales-pe": "^3.2.6",
     "node-vibrant": "^2.1.2",
-    "opencolor": "0.1.0"
+    "opencolor": "^0.2.0"
   }
 }

--- a/src/aco.js
+++ b/src/aco.js
@@ -1,5 +1,5 @@
 import {createImporter, createExporter} from './factory'
-import oco from 'opencolor'
+import {Entry, ColorValue} from 'opencolor'
 import Color from 'color'
 import binary from 'binary'
 
@@ -8,7 +8,7 @@ const defaultImporterOptions = {}
 export const importer = createImporter(defaultImporterOptions, (input, options) => {
   return new Promise((resolve, reject) => {
     var buf = input
-    var ocoPalette = new oco.Entry()
+    var ocoPalette = new Entry()
 
     // https:// github.com/teemualap/grunt-aco2less
     var nTotalColors = 0
@@ -124,7 +124,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
       if (color.colorSpace === 0) {
         // RGB
         var colorValue = Color().rgb(color.w / 256, color.x / 256, color.y / 256)
-        const colorEntry = new oco.Entry(colorName, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+        const colorEntry = new Entry(colorName, [ColorValue.fromColorValue(colorValue.hexString())])
 
         path.push(colorName)
 

--- a/src/image.js
+++ b/src/image.js
@@ -1,5 +1,5 @@
 import {createImporter, createExporter} from './factory'
-import oco from 'opencolor'
+import {Entry, ColorValue} from 'opencolor'
 import Color from 'color'
 import Vibrant from 'node-vibrant'
 import getColors from 'get-image-colors'
@@ -36,7 +36,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
           Promise.reject(e)
         }
 
-        var ocoPalette = new oco.Entry()
+        var ocoPalette = new Entry()
 
         function walk (key, value, path, parent, level) {
           path = path.slice(0)
@@ -60,7 +60,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
               if (options.readNameFromKey && typeof parent === 'object' && options.keyForName in parent) {
                 name = parent[options.keyForName]
               }
-              const color = new oco.Entry(name, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+              const color = new Entry(name, [ColorValue.fromColorValue(colorValue.hexString())])
               path.push(name)
               ocoPalette.set(path.join('.'), color)
             }
@@ -98,7 +98,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
           Promise.reject(e)
         }
 
-        var ocoPalette = new oco.Entry()
+        var ocoPalette = new Entry()
 
         function walk (key, value, path, parent, level) {
           path = path.slice(0)
@@ -122,7 +122,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
               if (options.readNameFromKey && typeof parent === 'object' && options.keyForName in parent) {
                 name = parent[options.keyForName]
               }
-              const color = new oco.Entry(name, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+              const color = new Entry(name, [ColorValue.fromColorValue(colorValue.hexString())])
               path.push(name)
               ocoPalette.set(path.join('.'), color)
             }

--- a/src/json.js
+++ b/src/json.js
@@ -1,5 +1,5 @@
 import {createImporter, createExporter} from './factory'
-import oco from 'opencolor'
+import {Entry, ColorValue} from 'opencolor'
 import Color from 'color'
 
 const defaultImporterOptions = {
@@ -19,7 +19,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
     Promise.reject(e)
   }
   return new Promise((resolve, reject) => {
-    var ocoPalette = new oco.Entry()
+    var ocoPalette = new Entry()
 
     function walk (key, value, path, parent, level) {
       path = path.slice(0)
@@ -43,7 +43,7 @@ export const importer = createImporter(defaultImporterOptions, (input, options) 
           if (options.readNameFromKey && typeof parent === 'object' && options.keyForName in parent) {
             name = parent[options.keyForName]
           }
-          const color = new oco.Entry(name, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+          const color = new Entry(name, [ColorValue.fromColorValue(colorValue.hexString())])
           path.push(name)
           ocoPalette.set(path.join('.'), color)
         }

--- a/src/stylesheet.js
+++ b/src/stylesheet.js
@@ -1,10 +1,10 @@
 import gonzales from 'gonzales-pe'
 import Color from 'color'
-import oco from 'opencolor'
+import {Entry, ColorValue, Reference} from 'opencolor'
 
 export const stylsheetImporter = function (input, options, syntax) {
   return new Promise((resolve, reject) => {
-    var ocoPalette = new oco.Entry()
+    var ocoPalette = new Entry()
 
     var parseTree = gonzales.parse(input, {syntax: syntax})
 
@@ -31,7 +31,7 @@ export const stylsheetImporter = function (input, options, syntax) {
       if (node.contains('color')) {
         var variableName = node.first('atkeyword').first('ident').content
         var colorValue = Color('#' + node.first('color').content)
-        var colorEntry = new oco.Entry(variableName, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+        var colorEntry = new Entry(variableName, [ColorValue.fromColorValue(colorValue.hexString())])
         ocoPalette.set(variableName, colorEntry)
       }
     })
@@ -43,11 +43,11 @@ export const stylsheetImporter = function (input, options, syntax) {
 
         if (node.contains('value') && node.first('value').contains('color')) {
           var colorValue = Color('#' + node.first('value').first('color').content)
-          var colorEntry = new oco.Entry(variableName, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+          var colorEntry = new Entry(variableName, [ColorValue.fromColorValue(colorValue.hexString())])
           ocoPalette.set(variableName, colorEntry)
         } else if (node.contains('value') && node.first('value').contains('variable')) {
           var path = node.first('value').first('variable').first('ident').content
-          var refrenceEntry = new oco.Reference(variableName, path)
+          var refrenceEntry = new Reference(variableName, path)
           ocoPalette.set(variableName, refrenceEntry)
         }
       }
@@ -58,7 +58,7 @@ export const stylsheetImporter = function (input, options, syntax) {
       if (node.contains('value') && node.first('value').contains('variable')) {
         var variableName = node.first('property').first('ident').content
         var path = node.first('value').first('variable').first('ident').content
-        var refrenceEntry = new oco.Reference(variableName, path)
+        var refrenceEntry = new Reference(variableName, path)
         ocoPalette.set(variableName, refrenceEntry)
       }
     })
@@ -86,11 +86,11 @@ export const stylsheetImporter = function (input, options, syntax) {
         node.traverseByTypes(['value'], (node, index, parent) => {
           node.traverseByTypes(['color'], (node, index, parent) => {
             var colorValue = Color('#' + node.content)
-            var colorEntry = new oco.Entry(cssProperty, [oco.ColorValue.fromColorValue(colorValue.hexString())])
+            var colorEntry = new Entry(cssProperty, [ColorValue.fromColorValue(colorValue.hexString())])
             addEntryWithSelectors(selectors, cssProperty, colorEntry)
           })
           node.traverseByTypes(['variable'], (node, index, parent) => {
-            var refrenceEntry = new oco.Reference(cssProperty, node.first('ident').content)
+            var refrenceEntry = new Reference(cssProperty, node.first('ident').content)
             addEntryWithSelectors(selectors, cssProperty, refrenceEntry)
           })
         })

--- a/test/css.js
+++ b/test/css.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import oco from 'opencolor'
+import {parse} from 'opencolor'
 import {importer, exporter} from '../src/css'
 
 describe('CSS Converter', () => {
@@ -46,7 +46,7 @@ describe('CSS Converter', () => {
   })
   describe('Exporter', () => {
     it('should export', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 `)
       return exporter(tree).then((scss) => {
@@ -54,7 +54,7 @@ one: #111111
       })
     })
     it('should export all entrys in root as vars', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 color: =one
 `)
@@ -64,7 +64,7 @@ color: =one
       })
     })
     it('should export groups (only turn names that are not a color attribute into vars)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -85,7 +85,7 @@ h1:
       })
     })
     it('should export groups (with turn all into vars options)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -100,7 +100,7 @@ h1:
       })
     })
     it('should export references', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 two: =one
 `)
@@ -110,7 +110,7 @@ two: =one
       })
     })
     it('should change names based on mapping', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 h1:
   fill: #FF0000
 `)

--- a/test/json.js
+++ b/test/json.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import oco from 'opencolor'
+import {parse} from 'opencolor'
 import {importer, exporter} from '../src/json'
 
 describe('JSON Converter', () => {
@@ -67,7 +67,7 @@ describe('JSON Converter', () => {
   })
   describe('Exporter', () => {
     it('should export', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 color: #111111
 `)
       return exporter(tree).then((json) => {
@@ -75,7 +75,7 @@ color: #111111
       })
     })
     it('should export sub palettes', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 group:
   one: #111111
 othergroup:
@@ -87,7 +87,7 @@ othergroup:
       })
     })
     it('should export references', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 group:
   one: #111111
 othergroup:

--- a/test/less.js
+++ b/test/less.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import oco from 'opencolor'
+import {parse} from 'opencolor'
 import {importer, exporter} from '../src/less'
 
 describe('Less Converter', () => {
@@ -59,7 +59,7 @@ body {
   })
   describe('Exporter', () => {
     it('should export', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 `)
       return exporter(tree).then((scss) => {
@@ -67,7 +67,7 @@ one: #111111
       })
     })
     it('should export all entrys in root as vars', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 color: =one
 `)
@@ -77,7 +77,7 @@ color: =one
       })
     })
     it('should export groups (only turn names that are not a color attribute into vars)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -98,7 +98,7 @@ h1:
       })
     })
     it('should export groups (with turn all into vars options)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -113,7 +113,7 @@ h1:
       })
     })
     it('should export references', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 two: =one
 `)
@@ -123,7 +123,7 @@ two: =one
       })
     })
     it('should change names based on mapping', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 h1:
   fill: #FF0000
 `)

--- a/test/scss.js
+++ b/test/scss.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import oco from 'opencolor'
+import {parse} from 'opencolor'
 import {importer, exporter} from '../src/scss'
 
 describe('SCSS Converter', () => {
@@ -59,7 +59,7 @@ body {
   })
   describe('Exporter', () => {
     it('should export', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 `)
       return exporter(tree).then((scss) => {
@@ -67,7 +67,7 @@ one: #111111
       })
     })
     it('should export all entrys in root as vars', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 color: =one
 `)
@@ -77,7 +77,7 @@ color: =one
       })
     })
     it('should export groups (only turn names that are not a color attribute into vars)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -98,7 +98,7 @@ h1:
       })
     })
     it('should export groups (with turn all into vars options)', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 h1:
   two: #FF0000
@@ -113,7 +113,7 @@ h1:
       })
     })
     it('should export references', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #111111
 two: =one
 `)
@@ -123,7 +123,7 @@ two: =one
       })
     })
     it('should change names based on mapping', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 h1:
   fill: #FF0000
 `)

--- a/test/swift.js
+++ b/test/swift.js
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
 import {expect} from 'chai'
-import oco from 'opencolor'
+import {parse} from 'opencolor'
 import {exporter} from '../src/swift'
 
 describe('Swift Converter', () => {
   describe('Exporter', () => {
     it('should export', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #FFFFFF
 `)
       return exporter(tree).then((scss) => {
@@ -14,7 +14,7 @@ one: #FFFFFF
       })
     })
     it('should export references', () => {
-      const tree = oco.parse(`
+      const tree = parse(`
 one: #FFFFFF
 two: =one
 `)


### PR DESCRIPTION
As opencolor 0.2.0 removes the default export, this allows us to import only parts of opencolor.

@theflow @rockitbaby Please take a look and merge at will.
